### PR TITLE
Add Warning Light to Custom-Gauge 

### DIFF
--- a/MyProjectTemplate.Client/myprojecttemplate.client.client/src/App.css
+++ b/MyProjectTemplate.Client/myprojecttemplate.client.client/src/App.css
@@ -141,6 +141,22 @@
     text-align: center;
 }
 
+.status-indicator {
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-left: 100px;
+    margin-bottom: -10px
+}
+.off {
+    background-color: #612825; /* Light Off */
+}
+.warning {
+    background-color: #ca0B00; /* Danger/Red */
+    box-shadow: 0 0 8px #F32013; /* Glowing effect */
+}
+
 
 /* wrapper inside the flex item so the gauge can center and scale */
 .gauge-wrapper {

--- a/MyProjectTemplate.Client/myprojecttemplate.client.client/src/Components/CustomGauge.jsx
+++ b/MyProjectTemplate.Client/myprojecttemplate.client.client/src/Components/CustomGauge.jsx
@@ -2,11 +2,12 @@ import React from 'react';
 import GaugeComponent from 'react-gauge-component';
 import '../App.css';
 
-const CustomGauge = ({ label = "", grad = false, value = 40, min = 0, max = 100, dLow = 20, wLow = 30, wHigh = 70, dHigh = 80, labelType = "", showLow = true, showHigh = true, showMinMax = false }) => {
+const CustomGauge = ({ warning = false, label = "", grad = false, value = 40, min = 0, max = 100, dLow = 20, wLow = 30, wHigh = 70, dHigh = 80, labelType = "", showLow = true, showHigh = true, showMinMax = false }) => {
     const v = value;
 
     return (
         <div className="gauge-wrapper">
+            {warning ? <div class="status-indicator warning"></div> : <div class="status-indicator off"></div>}
             <GaugeComponent
                 type="semicircle"
                 arc={{

--- a/MyProjectTemplate.Client/myprojecttemplate.client.client/src/Modules/LifeSupportPanel.jsx
+++ b/MyProjectTemplate.Client/myprojecttemplate.client.client/src/Modules/LifeSupportPanel.jsx
@@ -39,14 +39,17 @@ export default function LifeSupportPanel() {
             <div className="gauge-row">
                 <div className="gauge-item"> {/*O2/CO2 Gauges*/}
                     <CustomGauge
+                        warning={true}
                         label="O₂"
                         value={24}
                         min={16} max={25}
                         dLow={18} wLow={19}
                         wHigh={22} dHigh={23}
                         labelType="%"
+                         
                     />
                     <CustomGauge
+                        warning={false}
                         label="CO₂"
                         value={450}
                         min={300} max={2500}


### PR DESCRIPTION
Created A warning light for any gas/pressure Gauge that will turn on or off when the warning is set to true/false

Usable For:
- O2 Gauge
- CO2 Gauge
- External Pressure Gauge
- Internal Pressure Gauge
- Air Tank Fill % gauge (may need to be relocated manually when called, 

closes #13 
closes #14 